### PR TITLE
Fix README formatting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ usage: hashPlease.py [-h] [--showDetails] [--wordList WORDLIST]
 
 Generate hashes for different algs using wordlists and masks.
 
-optional arguments:
-  -h, --help           show this help message and exit
-  --showDetails        Wanna see the plaintext, mask/wordlist, and alg?
-  --wordList WORDLIST  Provide a custom wordlist to select passwords from.
-  --maskList MASKLIST  Provide a custom list of masks to generate passwords
+optional arguments:  
+  -h, --help           show this help message and exit  
+  --showDetails        Wanna see the plaintext, mask/wordlist, and alg?  
+  --wordList WORDLIST  Provide a custom wordlist to select passwords from.  
+  --maskList MASKLIST  Provide a custom list of masks to generate passwords  
                        from.


### PR DESCRIPTION
Markdown needs two spaces at the end of a line to replicate a <br/> in
rendered HTML.